### PR TITLE
fix of showing minus amount twice

### DIFF
--- a/html/js/app.js
+++ b/html/js/app.js
@@ -175,6 +175,7 @@ var moneyTimeout = null;
                 }, 3500)
             }
         }
+        if(data.type == "bank") {
             $(".money-bank").css("display", "block");
             $("#bank").html(data.bank);
             if (data.minus) {
@@ -196,6 +197,7 @@ var moneyTimeout = null;
                     });
                 }, 3500)
             }
+        }
     };
 
     window.onload = function(e) {


### PR DESCRIPTION
The fix of problem of showing a minus amount twice in the upper right part of the screen when purchasing something with cash. Tested with qb-atms and qb-banking too. Working correctly.

For example from a purchase from shop:
[Before](https://prnt.sc/1l6eb9g)
[After](https://prnt.sc/1l6ew59)