### PR TITLE
add engine health #16 and fix nil proximity again #19

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -9,6 +9,7 @@ local thirst = 100
 local cashAmount = 0
 local bankAmount = 0
 local isLoggedIn = false
+local engineHealth = 0
 
 -- Events
 
@@ -56,6 +57,8 @@ Citizen.CreateThread(function()
             local show = true
             local player = PlayerPedId()
             local talking = NetworkIsPlayerTalking(PlayerId())
+            local voice = 0
+            if LocalPlayer.state['proximity'] ~= nil then voice = LocalPlayer.state['proximity'].distance end
             if IsPauseMenuActive() then
                 show = false
             end
@@ -67,7 +70,7 @@ Citizen.CreateThread(function()
                 thirst = thirst,
                 hunger = hunger,
                 stress = stress,
-                voice = LocalPlayer.state['proximity'].distance,
+                voice = voice,
                 talking = talking,
             })
         else
@@ -95,6 +98,7 @@ Citizen.CreateThread(function()
                 local speed = GetEntitySpeed(vehicle) * 2.23694
                 local street1, street2 = GetStreetNameAtCoord(pos.x, pos.y, pos.z, Citizen.ResultAsInteger(), Citizen.ResultAsInteger())
                 local fuel = exports['LegacyFuel']:GetFuel(vehicle)
+                local engineHealth = Round(GetVehicleEngineHealth(vehicle), 1)
                 SendNUIMessage({
                     action = 'car',
                     show = true,
@@ -107,6 +111,7 @@ Citizen.CreateThread(function()
                     speed = math.ceil(speed),
                     nos = nos,
                     fuel = fuel,
+                    engineHealth = engineHealth
                 })
             else
                 SendNUIMessage({

--- a/html/app.js
+++ b/html/app.js
@@ -167,6 +167,9 @@ app.use(Quasar)
 app.mount('#ui-container');
 
 // VEHICLE HUD
+const healthyColor = '#28a745';
+const warningColor = '#c08700';
+const dangerColor = '#DC143C';
 
 const vehHud = {
     data() {
@@ -182,7 +185,9 @@ const vehHud = {
             seatbelt: 0,
             direction: '',
             cruiseColor: '',
-            seatbeltColor: ''
+            seatbeltColor: '',
+            engineHealth: 0,
+            engineColor: ''
         }
     },
     destroyed() {
@@ -206,17 +211,17 @@ const vehHud = {
             this.nos = data.nos;
             if (data.seatbelt === true) {
                 this.seatbelt = 1;
-                this.seatbeltColor = '#28a745';
+                this.seatbeltColor = healthyColor;
             } else {
                 this.seatbelt = 0;
-                this.seatbeltColor = '#DC143C';
+                this.seatbeltColor = dangerColor;
             }
             if (data.cruise === true) {
                 this.cruise = 1;
-                this.cruiseColor = '#28a745';
+                this.cruiseColor = healthyColor;
             } else {
                 this.cruise = 0;
-                this.cruiseColor = '#DC143C';
+                this.cruiseColor = warningColor;
             }
             if (data.nos === 0 || data.nos === undefined) {
                 this.showNos = false;
@@ -226,6 +231,10 @@ const vehHud = {
             if (data.isPaused === 1) {
                 this.show = false;
             }
+            this.engineHealth = data.engineHealth / 1000
+            if (this.engineHealth >= 0.7 ) this.engineColor = healthyColor;
+            else if (this.engineHealth >= 0.4 && this.engineHealth < 0.7) this.engineColor = warningColor;
+            else this.engineColor = dangerColor;
         },
     }
 }

--- a/html/app.js
+++ b/html/app.js
@@ -221,7 +221,7 @@ const vehHud = {
                 this.cruiseColor = healthyColor;
             } else {
                 this.cruise = 0;
-                this.cruiseColor = warningColor;
+                this.cruiseColor = dangerColor;
             }
             if (data.nos === 0 || data.nos === undefined) {
                 this.showNos = false;

--- a/html/index.html
+++ b/html/index.html
@@ -61,6 +61,9 @@
                     <div class="ui-car-fuel">
                         <q-circular-progress show-value :value="fuel" size="30px" :thickness="0.1" color="orange" track-color="grey-9" center-color="grey-8"><q-icon name="fas fa-gas-pump" size="11px" color="orange"/>
                     </div>
+                    <div class="ui-car-engine">
+                        <q-circular-progress show-value :value="engineHealth" size="30px" :thickness="0" color="white" track-color="grey-9" center-color="grey-8"><q-icon name="fas fa-exclamation" size="11px" :style="{color: engineColor}"/>
+                    </div>
                     <div class="ui-car-nos" v-if="showNos">
                         <q-circular-progress show-value :value="nos" size="30px" :thickness="0.1" color="blue" track-color="grey-9" center-color="grey-8"><q-icon name="fas fa-fire-alt" size="12px" color="blue"/>
                     </div>

--- a/html/styles.css
+++ b/html/styles.css
@@ -42,7 +42,7 @@
 
 /* Vehicle HUD */
 
-.ui-car-fuel, .ui-car-nos {
+.ui-car-fuel, .ui-car-nos, .ui-car-engine {
     position: absolute;
 }
 
@@ -69,6 +69,11 @@
 .ui-car-seatbelt {
     left: 19.1vw;
     bottom: 3.56vw;
+}
+
+.ui-car-engine {
+    left: 16.8vw;
+    bottom: 5.3vw;
 }
 
 .ui-car-cruise {


### PR DESCRIPTION
This adds an engine health icon as suggested in #16  to the car hud that changes color (green, orange, red) depending on the health of the engine. 

Note - this may seem to contradict the health of the car (e.g. unable to drive) because of other damages and damages in qb-vehicle failure.

This also fixes includes a fix for the proximity bug that was reintroduced #5 (#19)  //

![qb-hudEngineHealth](https://user-images.githubusercontent.com/8097956/131255767-3dbcc4f0-85e2-40ac-a6bf-5fc4f72cb67f.PNG)
