### PR TITLE
Tiny margin to bottom of HUD

### DIFF
--- a/html/styles.css
+++ b/html/styles.css
@@ -36,7 +36,7 @@
 #playerhud {
     display: flex;
     position: absolute;
-    bottom: 0vw;
+    bottom: 0.4vw;
     left: 2.5vh;
 }
 

--- a/html/styles.css
+++ b/html/styles.css
@@ -36,7 +36,7 @@
 #playerhud {
     display: flex;
     position: absolute;
-    bottom: 0.4vw;
+    bottom: 0.3vw;
     left: 2.5vh;
 }
 


### PR DESCRIPTION
HUD icons were dead on edge of screen, didn't look quite right, needs a tiny bit of margin to break away from the screen edge, but not a lot to start overlapping on the map location.