### PR TITLE
Optimize, adjust html and fix a bug

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -95,7 +95,7 @@ local lastCrossroadCheck = {}
 
 local function getCrossroads(player)
     local updateTick = GetGameTimer()
-    if (updateTick - lastCrossroadUpdate) > 1500 then
+    if updateTick - lastCrossroadUpdate > 1500 then
         local pos = GetEntityCoords(player)
         local street1, street2 = GetStreetNameAtCoord(pos.x, pos.y, pos.z)
         lastCrossroadUpdate = updateTick
@@ -132,12 +132,13 @@ CreateThread(function()
         if LocalPlayer.state.isLoggedIn then
             local show = true
             local player = PlayerPedId()
+            local playerId = PlayerId()
             -- player hud
-            local oxygen = GetPlayerUnderwaterTimeRemaining(PlayerId()) * 10
-            local stamina = GetPlayerSprintStaminaRemaining(PlayerId()) * 1
-            local talking = NetworkIsPlayerTalking(PlayerId())
+            local oxygen = GetPlayerUnderwaterTimeRemaining(playerId) * 10
+            local stamina = GetPlayerSprintStaminaRemaining(playerId)
+            local talking = NetworkIsPlayerTalking(playerId)
             local voice = 0
-            if LocalPlayer.state['proximity'] ~= nil then
+            if LocalPlayer.state['proximity'] then
                 voice = LocalPlayer.state['proximity'].distance
             end
             if IsPauseMenuActive() then
@@ -152,7 +153,6 @@ CreateThread(function()
                 stress,
                 oxygen,
                 stamina,
-                talking,
                 voice,
                 LocalPlayer.state['radioChannel'],
                 talking

--- a/html/index.html
+++ b/html/index.html
@@ -46,10 +46,10 @@
                         <q-circular-progress class="q-ml-xs" show-value :value="stress" size="45px" :thickness="0.2" color="red" track-color="grey-9" center-color="grey-10"><q-icon name="fas fa-brain" size="19px" color="white"/>
                     </div>
                     <div v-if="showOxygen">
-                        <q-circular-progress class="q-ml-xs" show-value :value="oxygen" size="45px" :thickness="0.2" color="blue" track-color="grey-9" center-color="grey-8"><q-icon name="fas fa-swimmer" size="19px" color="white"/>
+                        <q-circular-progress class="q-ml-xs" show-value :value="oxygen" size="45px" :thickness="0.2" color="blue" track-color="grey-9" center-color="grey-10"><q-icon name="fas fa-swimmer" size="19px" color="white"/>
                     </div>
                     <div v-if="showStamina">
-                        <q-circular-progress class="q-ml-xs" show-value :value="stamina" size="45px" :thickness="0.2" color="purple" track-color="grey-9" center-color="grey-8"><q-icon name="fas fa-lungs" size="19px" color="white"/>
+                        <q-circular-progress class="q-ml-xs" show-value :value="stamina" size="45px" :thickness="0.2" color="purple" track-color="grey-9" center-color="grey-10"><q-icon name="fas fa-lungs" size="19px" color="white"/>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
This optimizes the main hud loop, adjusts the background colors of the icons of stamina and oxygen to align with the others and this includes the fix from https://github.com/qbcore-framework/qb-hud/pull/65