### PR TITLE
harnass item check and square map component position

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -324,7 +324,7 @@ RegisterNetEvent("hud:client:LoadMap", function()
         SetMinimapComponentPosition("minimap", "L", "B", 0.0 + minimapOffset, -0.047, 0.1638, 0.183)
 
         -- icons within map
-        SetMinimapComponentPosition("minimap_mask", "L", "B", 0.2 + minimapOffset, 0.0, 0.065, 0.20)
+        SetMinimapComponentPosition("minimap_mask", "L", "B", 0.0 + minimapOffset, 0.0, 0.128, 0.20)
 
         -- -0.01 = map pulled left
         -- 0.025 = map raised up

--- a/client.lua
+++ b/client.lua
@@ -684,13 +684,7 @@ CreateThread(function()
                     DisplayRadar(true)
                 end
                 wasInVehicle = true
-                QBCore.Functions.TriggerCallback('hud:server:HasHarness', function(hasItem)
-                    if hasItem then
-                        harness = true
-                    else
-                        harness = false
-                    end
-                end, "harness")
+                harness = QBCore.Functions.HasItem('harness')
                 updatePlayerHud({
                     show,
                     Menu.isDynamicHealthChecked,


### PR DESCRIPTION
**Describe Pull request**
This will utilise a better way of checking items, this also fixes the item check not working at all as my first PR removed that callback whilst this check was still in with the revert and this also fixes the weird component position of the minimap mask for the square map

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
