### PR TITLE
Prevent pause menu engine halt

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -490,13 +490,19 @@ end)
 
 RegisterCommand('+engine', function()
     local vehicle = GetVehiclePedIsIn(PlayerPedId(), false)
-    if vehicle == 0 or GetPedInVehicleSeat(vehicle, -1) ~= PlayerPedId() then return end
-    if GetIsVehicleEngineRunning(vehicle) then
-        QBCore.Functions.Notify(Lang:t("notify.engine_off"))
-    else
-        QBCore.Functions.Notify(Lang:t("notify.engine_on"))
+	local pause = IsPauseMenuActive()
+    if vehicle ~= nil and vehicle ~= 0 and GetPedInVehicleSeat(vehicle, 0) then
+		if pause == false then
+			if GetPedInVehicleSeat(vehicle, -1) == PlayerPedId() then
+				if (GetIsVehicleEngineRunning(vehicle)) then
+					QBCore.Functions.Notify('Engine halted!', "error")
+				else
+					QBCore.Functions.Notify('Engine started!')
+				end
+				SetVehicleEngineOn(vehicle, (not GetIsVehicleEngineRunning(vehicle)), false, true)
+			end
+		end
     end
-    SetVehicleEngineOn(vehicle, not GetIsVehicleEngineRunning(vehicle), false, true)
 end)
 
 RegisterKeyMapping('+engine', 'Toggle Engine', 'keyboard', 'G')

--- a/client.lua
+++ b/client.lua
@@ -490,18 +490,18 @@ end)
 
 RegisterCommand('+engine', function()
     local vehicle = GetVehiclePedIsIn(PlayerPedId(), false)
-	local pause = IsPauseMenuActive()
+    local pause = IsPauseMenuActive()
     if vehicle ~= nil and vehicle ~= 0 and GetPedInVehicleSeat(vehicle, 0) then
-		if pause == false then
-			if GetPedInVehicleSeat(vehicle, -1) == PlayerPedId() then
-				if (GetIsVehicleEngineRunning(vehicle)) then
-					QBCore.Functions.Notify('Engine halted!', "error")
-				else
-					QBCore.Functions.Notify('Engine started!')
-				end
-				SetVehicleEngineOn(vehicle, (not GetIsVehicleEngineRunning(vehicle)), false, true)
-			end
-		end
+        if pause == false then
+            if GetPedInVehicleSeat(vehicle, -1) == PlayerPedId() then
+                if (GetIsVehicleEngineRunning(vehicle)) then
+                    QBCore.Functions.Notify('Engine halted!', "error")
+                else
+                    QBCore.Functions.Notify('Engine started!')
+                end
+                SetVehicleEngineOn(vehicle, (not GetIsVehicleEngineRunning(vehicle)), false, true)
+            end
+        end
     end
 end)
 

--- a/client.lua
+++ b/client.lua
@@ -494,10 +494,10 @@ RegisterCommand('+engine', function()
     if vehicle ~= nil and vehicle ~= 0 and GetPedInVehicleSeat(vehicle, 0) then
         if pause == false then
             if GetPedInVehicleSeat(vehicle, -1) == PlayerPedId() then
-                if (GetIsVehicleEngineRunning(vehicle)) then
-                    QBCore.Functions.Notify('Engine halted!', "error")
+                if GetIsVehicleEngineRunning(vehicle) then
+                    QBCore.Functions.Notify(Lang:t("notify.engine_off"))
                 else
-                    QBCore.Functions.Notify('Engine started!')
+                    QBCore.Functions.Notify(Lang:t("notify.engine_on"))
                 end
                 SetVehicleEngineOn(vehicle, (not GetIsVehicleEngineRunning(vehicle)), false, true)
             end


### PR DESCRIPTION
If the toggle engine key is set to mouse wheel, this will prevent the engine stop/start when in the pause menu.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? Yes
- Does your code fit the style guidelines? Yes
- Does your PR fit the contribution guidelines? Yes