### PR TITLE
[Hotfix] Cash UI Location

### DIFF
--- a/html/styles.css
+++ b/html/styles.css
@@ -58,7 +58,7 @@ div#q-loading-bar { display: none!important; } /* makes sure there's no ajax loa
 #money-container {
   position: absolute;
   right: 2vw;
-  top: 2vh;
+  top: 5vh;
   font-weight: 400;
   font-size: 40px;
 }


### PR DESCRIPTION
Moved cash/bank amount ui lower to not block the ammo visual