### PR TITLE
Disable low fuel alert for bicycles

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -809,7 +809,7 @@ CreateThread(function()
     while true do
         if LocalPlayer.state.isLoggedIn then
             local ped = PlayerPedId()
-            if IsPedInAnyVehicle(ped, false) then
+            if IsPedInAnyVehicle(ped, false) and not IsThisModelABicycle(GetEntityModel(GetVehiclePedIsIn(ped, false))) then
                 if exports['LegacyFuel']:GetFuel(GetVehiclePedIsIn(ped, false)) <= 20 then -- At 20% Fuel Left
                     if Menu.isLowFuelChecked then
                         TriggerServerEvent("InteractSound_SV:PlayOnSource", "pager", 0.10)


### PR DESCRIPTION
The thread checking for low fuel does not exclude bicycles, and as a result, low fuel alerts occur incessantly for players riding bicycles. Ensuring that a vehicle is not a bicycle before checking if the fuel level is low and subsequently alerting prevents this alert from occurring for players riding bicycles.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? Yes
- Does your code fit the style guidelines? Yes
- Does your PR fit the contribution guidelines? Yes
