### PR TITLE
Update stress gain

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -925,6 +925,7 @@ CreateThread(function() -- Speeding
                 local stressSpeed = seatbeltOn and config.MinimumSpeed or config.MinimumSpeedUnbuckled
                 if speed >= stressSpeed then
                     TriggerServerEvent('hud:server:GainStress', math.random(1, 3))
+                    Wait(60000)
                 end
             end
         end


### PR DESCRIPTION
Updated the stress grain thread, since people were complaining about being too stressed too often.
Now it takes 60 seconds before it starts to check the car speed to add stress again.

I think it is better balanced now, but this is of course in my opinion, so it might need some testing from others to see if they agree on it.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [no]
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
