### PR TITLE
Add more stress configuration

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -1,7 +1,6 @@
 local QBCore = exports['qb-core']:GetCoreObject()
 local PlayerData = QBCore.Functions.GetPlayerData()
-local config = Config
-local speedMultiplier = config.UseMPH and 2.23694 or 3.6
+local speedMultiplier = Config.UseMPH and 2.23694 or 3.6
 local seatbeltOn = false
 local cruiseOn = false
 local showAltitude = false
@@ -23,7 +22,7 @@ local playerDead = false
 local showMenu = false
 local showCircleB = false
 local showSquareB = false
-local Menu = config.Menu
+local Menu = Config.Menu
 local CinematicHeight = 0.2
 local w = 0
 
@@ -582,7 +581,7 @@ end)
 
 local function IsWhitelistedWeaponArmed(weapon)
     if weapon then
-        for _, v in pairs(config.WhitelistedWeaponArmed) do
+        for _, v in pairs(Config.WhitelistedWeaponArmed) do
             if weapon == v then
                 return true
             end
@@ -898,21 +897,44 @@ end)
 
 -- Stress Gain
 
+local function IsWhitelistedVehClass(vehClass)
+    if vehClass then
+        for _, v in pairs(Config.WhitelistedVehClasses) do
+            if vehClass == v then
+                return true
+            end
+        end
+    end
+    return false
+end
+
+local function IsWhitelistedVehicle(vehHash)
+    if vehHash then
+        for _, v in pairs(Config.WhitelistedVehicles) do
+            if vehHash == GetHashKey(v) then
+                return true
+            end
+        end
+    end
+    return false
+end
+
 CreateThread(function() -- Speeding
     while true do
         if LocalPlayer.state.isLoggedIn then
             local ped = PlayerPedId()
             if IsPedInAnyVehicle(ped, false) then
                 local veh = GetVehiclePedIsIn(ped, false)
+                local vehHash = GetEntityModel(veh)
                 local vehClass = GetVehicleClass(veh)
                 local speed = GetEntitySpeed(veh) * speedMultiplier
 
-                if vehClass ~= 13 and vehClass ~= 14 and vehClass ~= 15 and vehClass ~= 16 and vehClass ~= 21 then
+                if not IsWhitelistedVehClass(vehClass) and not IsWhitelistedVehicle(vehHash) then
                     local stressSpeed
                     if vehClass == 8 then
-                        stressSpeed = config.MinimumSpeed
+                        stressSpeed = Config.MinimumSpeed
                     else
-                        stressSpeed = seatbeltOn and config.MinimumSpeed or config.MinimumSpeedUnbuckled
+                        stressSpeed = seatbeltOn and Config.MinimumSpeed or Config.MinimumSpeedUnbuckled
                     end
                     if speed >= stressSpeed then
                         TriggerServerEvent('hud:server:GainStress', math.random(1, 3))
@@ -926,7 +948,7 @@ end)
 
 local function IsWhitelistedWeaponStress(weapon)
     if weapon then
-        for _, v in pairs(config.WhitelistedWeaponStress) do
+        for _, v in pairs(Config.WhitelistedWeaponStress) do
             if weapon == v then
                 return true
             end
@@ -942,7 +964,7 @@ CreateThread(function() -- Shooting
             local weapon = GetSelectedPedWeapon(ped)
             if weapon ~= `WEAPON_UNARMED` then
                 if IsPedShooting(ped) and not IsWhitelistedWeaponStress(weapon) then
-                    if math.random() < config.StressChance then
+                    if math.random() < Config.StressChance then
                         TriggerServerEvent('hud:server:GainStress', math.random(1, 3))
                     end
                 end
@@ -957,7 +979,7 @@ end)
 -- Stress Screen Effects
 
 local function GetBlurIntensity(stresslevel)
-    for _, v in pairs(config.Intensity['blur']) do
+    for _, v in pairs(Config.Intensity['blur']) do
         if stresslevel >= v.min and stresslevel <= v.max then
             return v.intensity
         end
@@ -966,7 +988,7 @@ local function GetBlurIntensity(stresslevel)
 end
 
 local function GetEffectInterval(stresslevel)
-    for _, v in pairs(config.EffectInterval) do
+    for _, v in pairs(Config.EffectInterval) do
         if stresslevel >= v.min and stresslevel <= v.max then
             return v.timeout
         end
@@ -1000,7 +1022,7 @@ CreateThread(function()
                 Wait(BlurIntensity)
                 TriggerScreenblurFadeOut(1000.0)
             end
-        elseif stress >= config.MinimumStress then
+        elseif stress >= Config.MinimumStress then
             local BlurIntensity = GetBlurIntensity(stress)
             TriggerScreenblurFadeIn(1000.0)
             Wait(BlurIntensity)

--- a/client.lua
+++ b/client.lua
@@ -47,21 +47,21 @@ local function CinematicShow(bool)
 end
 
 local function loadSettings(settings)
-    for k,v in pairs(settings) do
+    for k, v in pairs(settings) do
         if k == 'isToggleMapShapeChecked' then
             Menu.isToggleMapShapeChecked = v
-            SendNUIMessage({ test = true, event = k, toggle = v})
+            SendNUIMessage({ test = true, event = k, toggle = v })
         elseif k == 'isCineamticModeChecked' then
             Menu.isCineamticModeChecked = v
             CinematicShow(v)
-            SendNUIMessage({ test = true, event = k, toggle = v})
+            SendNUIMessage({ test = true, event = k, toggle = v })
         elseif k == 'isChangeFPSChecked' then
             Menu[k] = v
             local val = v and 'Optimized' or 'Synced'
-            SendNUIMessage({ test = true, event = k, toggle = val})
+            SendNUIMessage({ test = true, event = k, toggle = val })
         else
             Menu[k] = v
-            SendNUIMessage({ test = true, event = k, toggle = v})
+            SendNUIMessage({ test = true, event = k, toggle = v })
         end
     end
     QBCore.Functions.Notify(Lang:t("notify.hud_settings_loaded"), "success")
@@ -121,7 +121,7 @@ RegisterCommand('menu', function()
     if showMenu then return end
     TriggerEvent("hud:client:playOpenMenuSounds")
     SetNuiFocus(true, true)
-    SendNUIMessage({ action = "open"})
+    SendNUIMessage({ action = "open" })
     showMenu = true
 end)
 
@@ -174,7 +174,10 @@ RegisterNetEvent("hud:client:resetStorage", function()
     if Menu.isResetSoundsChecked then
         TriggerServerEvent("InteractSound_SV:PlayOnSource", "airwrench", 0.1)
     end
-    QBCore.Functions.TriggerCallback('hud:server:getMenu', function(menu) loadSettings(menu); SetResourceKvp('hudSettings', json.encode(menu)) end)
+    QBCore.Functions.TriggerCallback('hud:server:getMenu', function(menu)
+        loadSettings(menu);
+        SetResourceKvp('hudSettings', json.encode(menu))
+    end)
 end)
 
 -- Notifications
@@ -248,7 +251,7 @@ RegisterNUICallback('showOutCompass', function(_, cb)
 end)
 
 RegisterNUICallback('showFollowCompass', function(_, cb)
-	Wait(50)
+    Wait(50)
     Menu.isCompassFollowChecked = not Menu.isCompassFollowChecked
     TriggerEvent("hud:client:playHudChecklistSound")
     saveSettings()
@@ -354,12 +357,12 @@ end)
 RegisterNetEvent("hud:client:LoadMap", function()
     Wait(50)
     -- Credit to Dalrae for the solve.
-    local defaultAspectRatio = 1920/1080 -- Don't change this.
+    local defaultAspectRatio = 1920 / 1080 -- Don't change this.
     local resolutionX, resolutionY = GetActiveScreenResolution()
-    local aspectRatio = resolutionX/resolutionY
+    local aspectRatio = resolutionX / resolutionY
     local minimapOffset = 0
     if aspectRatio > defaultAspectRatio then
-        minimapOffset = ((defaultAspectRatio-aspectRatio)/3.6)-0.008
+        minimapOffset = ((defaultAspectRatio - aspectRatio) / 3.6) - 0.008
     end
     if Menu.isToggleMapShapeChecked == "square" then
         RequestStreamedTextureDict("squaremap", false)
@@ -486,7 +489,7 @@ end)
 
 -- Compass
 RegisterNUICallback('showCompassBase', function(_, cb)
-	Wait(50)
+    Wait(50)
     Menu.isCompassShowChecked = not Menu.isCompassShowChecked
     TriggerEvent("hud:client:playHudChecklistSound")
     saveSettings()
@@ -494,7 +497,7 @@ RegisterNUICallback('showCompassBase', function(_, cb)
 end)
 
 RegisterNUICallback('showStreetsNames', function(_, cb)
-	Wait(50)
+    Wait(50)
     Menu.isShowStreetsChecked = not Menu.isShowStreetsChecked
     TriggerEvent("hud:client:playHudChecklistSound")
     saveSettings()
@@ -502,7 +505,7 @@ RegisterNUICallback('showStreetsNames', function(_, cb)
 end)
 
 RegisterNUICallback('showPointerIndex', function(_, cb)
-	Wait(50)
+    Wait(50)
     Menu.isPointerShowChecked = not Menu.isPointerShowChecked
     TriggerEvent("hud:client:playHudChecklistSound")
     saveSettings()
@@ -510,7 +513,7 @@ RegisterNUICallback('showPointerIndex', function(_, cb)
 end)
 
 RegisterNUICallback('showDegreesNum', function(_, cb)
-	Wait(50)
+    Wait(50)
     Menu.isDegreesShowChecked = not Menu.isDegreesShowChecked
     TriggerEvent("hud:client:playHudChecklistSound")
     saveSettings()
@@ -518,7 +521,7 @@ RegisterNUICallback('showDegreesNum', function(_, cb)
 end)
 
 RegisterNUICallback('changeCompassFPS', function(_, cb)
-	Wait(50)
+    Wait(50)
     Menu.isChangeCompassFPSChecked = not Menu.isChangeCompassFPSChecked
     TriggerEvent("hud:client:playHudChecklistSound")
     saveSettings()
@@ -584,9 +587,9 @@ RegisterNetEvent("qb-admin:client:ToggleDevmode", function()
     dev = not dev
 end)
 
-local function IsWhitelistedWeaponArmed(weapon)
+local function IsNotWeaponArmed(weapon)
     if weapon then
-        for _, v in pairs(Config.WhitelistedWeaponArmed) do
+        for _, v in pairs(Config.WeaponNotArmed) do
             if weapon == v then
                 return true
             end
@@ -649,7 +652,10 @@ local prevVehicleStats = { nil, nil, nil, nil, nil, nil, nil, nil, nil, nil }
 local function updateVehicleHud(data)
     local shouldUpdate = false
     for k, v in pairs(data) do
-        if prevVehicleStats[k] ~= v then shouldUpdate = true break end
+        if prevVehicleStats[k] ~= v then
+            shouldUpdate = true
+            break
+        end
     end
     prevVehicleStats = data
     if shouldUpdate then
@@ -697,7 +703,7 @@ CreateThread(function()
             local playerId = PlayerId()
             local weapon = GetSelectedPedWeapon(player)
             -- Player hud
-            if not IsWhitelistedWeaponArmed(weapon) then
+            if not IsNotWeaponArmed(weapon) then
                 if weapon ~= `WEAPON_UNARMED` then
                     armed = true
                 else
@@ -725,39 +731,39 @@ CreateThread(function()
             end
             local vehicle = GetVehiclePedIsIn(player)
             if not (IsPedInAnyVehicle(player) and not IsThisModelABicycle(vehicle)) then
-            updatePlayerHud({
-                show,
-                Menu.isDynamicHealthChecked,
-                Menu.isDynamicArmorChecked,
-                Menu.isDynamicHungerChecked,
-                Menu.isDynamicThirstChecked,
-                Menu.isDynamicStressChecked,
-                Menu.isDynamicOxygenChecked,
-                Menu.isDynamicEngineChecked,
-                Menu.isDynamicNitroChecked,
-                GetEntityHealth(player) - 100,
-                playerDead,
-                GetPedArmour(player),
-                thirst,
-                hunger,
-                stress,
-                voice,
-                LocalPlayer.state['radioChannel'],
-                talking,
-                armed,
-                oxygen,
-                parachute,
-                -1,
-                cruiseOn,
-                nitroActive,
-                harness,
-                hp,
-                math.ceil(GetEntitySpeed(vehicle) * speedMultiplier),
-                -1,
-                Menu.isCineamticModeChecked,
-                dev,
-                radioActive,
-            })
+                updatePlayerHud({
+                    show,
+                    Menu.isDynamicHealthChecked,
+                    Menu.isDynamicArmorChecked,
+                    Menu.isDynamicHungerChecked,
+                    Menu.isDynamicThirstChecked,
+                    Menu.isDynamicStressChecked,
+                    Menu.isDynamicOxygenChecked,
+                    Menu.isDynamicEngineChecked,
+                    Menu.isDynamicNitroChecked,
+                    GetEntityHealth(player) - 100,
+                    playerDead,
+                    GetPedArmour(player),
+                    thirst,
+                    hunger,
+                    stress,
+                    voice,
+                    LocalPlayer.state['radioChannel'],
+                    talking,
+                    armed,
+                    oxygen,
+                    parachute,
+                    -1,
+                    cruiseOn,
+                    nitroActive,
+                    harness,
+                    hp,
+                    math.ceil(GetEntitySpeed(vehicle) * speedMultiplier),
+                    -1,
+                    Menu.isCineamticModeChecked,
+                    dev,
+                    radioActive,
+                })
             end
             -- Vehicle hud
             if IsPedInAnyHeli(player) or IsPedInAnyPlane(player) then
@@ -905,9 +911,9 @@ end)
 
 -- Stress Gain
 
-local function IsWhitelistedVehClass(vehClass)
+local function IsStressDisabledVehClass(vehClass)
     if vehClass then
-        for _, v in pairs(Config.WhitelistedVehClasses) do
+        for _, v in pairs(Config.StressDisabledVehClasses) do
             if vehClass == v then
                 return true
             end
@@ -916,9 +922,9 @@ local function IsWhitelistedVehClass(vehClass)
     return false
 end
 
-local function IsWhitelistedVehicle(vehHash)
+local function IsStressDisabledVehicle(vehHash)
     if vehHash then
-        for _, v in pairs(Config.WhitelistedVehicles) do
+        for _, v in pairs(Config.StressDisabledVehicles) do
             if vehHash == GetHashKey(v) then
                 return true
             end
@@ -937,7 +943,7 @@ CreateThread(function() -- Speeding
                 local vehClass = GetVehicleClass(veh)
                 local speed = GetEntitySpeed(veh) * speedMultiplier
 
-                if not IsWhitelistedVehClass(vehClass) and not IsWhitelistedVehicle(vehHash) then
+                if not IsStressDisabledVehClass(vehClass) and not IsStressDisabledVehicle(vehHash) then
                     local stressSpeed
                     if vehClass == 8 then
                         stressSpeed = Config.MinimumSpeed
@@ -954,9 +960,9 @@ CreateThread(function() -- Speeding
     end
 end)
 
-local function IsWhitelistedWeaponStress(weapon)
+local function IsStressDisabledWeapon(weapon)
     if weapon then
-        for _, v in pairs(Config.WhitelistedWeaponStress) do
+        for _, v in pairs(Config.StressDisabledWeapon) do
             if weapon == v then
                 return true
             end
@@ -971,7 +977,7 @@ CreateThread(function() -- Shooting
             local ped = PlayerPedId()
             local weapon = GetSelectedPedWeapon(ped)
             if weapon ~= `WEAPON_UNARMED` then
-                if IsPedShooting(ped) and not IsWhitelistedWeaponStress(weapon) then
+                if IsPedShooting(ped) and not IsStressDisabledWeapon(weapon) then
                     if math.random() < Config.StressChance then
                         TriggerServerEvent('hud:server:GainStress', math.random(1, 3))
                     end
@@ -1081,20 +1087,23 @@ end)
 
 -- Compass
 function round(num, numDecimalPlaces)
-    local mult = 10^(numDecimalPlaces or 0)
+    local mult = 10 ^ (numDecimalPlaces or 0)
     return math.floor(num + 0.5 * mult)
 end
 
-local prevBaseplateStats = { nil, nil, nil, nil, nil, nil, nil}
+local prevBaseplateStats = { nil, nil, nil, nil, nil, nil, nil }
 
 local function updateBaseplateHud(data)
     local shouldUpdate = false
     for k, v in pairs(data) do
-        if prevBaseplateStats[k] ~= v then shouldUpdate = true break end
+        if prevBaseplateStats[k] ~= v then
+            shouldUpdate = true
+            break
+        end
     end
     prevBaseplateStats = data
     if shouldUpdate then
-        SendNUIMessage ({
+        SendNUIMessage({
             action = 'baseplate',
             show = data[1],
             street1 = data[2],
@@ -1124,9 +1133,9 @@ end
 -- Compass Update loop
 
 CreateThread(function()
-	local lastHeading = 1
+    local lastHeading = 1
     local heading
-	while true do
+    while true do
         if Menu.isChangeCompassFPSChecked then
             Wait(50)
         else
@@ -1140,42 +1149,42 @@ CreateThread(function()
         else
             heading = tostring(round(360.0 - GetEntityHeading(player)))
         end
-		if heading == '360' then heading = '0' end
-            if heading ~= lastHeading then
-			    if IsPedInAnyVehicle(player) then
-                    local crossroads = getCrossroads(player)
-                    SendNUIMessage ({
+        if heading == '360' then heading = '0' end
+        if heading ~= lastHeading then
+            if IsPedInAnyVehicle(player) then
+                local crossroads = getCrossroads(player)
+                SendNUIMessage({
+                    action = 'update',
+                    value = heading
+                })
+                updateBaseplateHud({
+                    show,
+                    crossroads[1],
+                    crossroads[2],
+                    Menu.isCompassShowChecked,
+                    Menu.isShowStreetsChecked,
+                    Menu.isPointerShowChecked,
+                    Menu.isDegreesShowChecked,
+                })
+            else
+                if Menu.isOutCompassChecked then
+                    SendNUIMessage({
                         action = 'update',
                         value = heading
                     })
-                    updateBaseplateHud({
-                        show,
-                        crossroads[1],
-                        crossroads[2],
-                        Menu.isCompassShowChecked,
-                        Menu.isShowStreetsChecked,
-                        Menu.isPointerShowChecked,
-                        Menu.isDegreesShowChecked,
+                    SendNUIMessage({
+                        action = 'baseplate',
+                        show = true,
+                        showCompass = true,
                     })
-			    else
-                    if Menu.isOutCompassChecked then
-                        SendNUIMessage ({
-                            action = 'update',
-                            value = heading
-                        })
-                        SendNUIMessage ({
-                            action = 'baseplate',
-                            show = true,
-                            showCompass = true,
-                        })
-                    else
-                        SendNUIMessage ({
-                            action = 'baseplate',
-                            show = false,
-                        })
-                    end
-			    end
-	        end
-		    lastHeading = heading
-	    end
+                else
+                    SendNUIMessage({
+                        action = 'baseplate',
+                        show = false,
+                    })
+                end
+            end
+        end
+        lastHeading = heading
+    end
 end)

--- a/config.lua
+++ b/config.lua
@@ -1,20 +1,20 @@
 Config = {}
 
-Config.OpenMenu = 'I' -- https://docs.fivem.net/docs/game-references/input-mapper-parameter-ids/keyboard/
-Config.StressChance = 0.1 -- Default: 10% -- Percentage Stress Chance When Shooting (0-1)
-Config.UseMPH = true -- If true speed math will be done as MPH, if false KPH will be used (YOU HAVE TO CHANGE CONTENT IN STYLES.CSS TO DISPLAY THE CORRECT TEXT)
-Config.MinimumStress = 50 -- Minimum Stress Level For Screen Shaking
+Config.OpenMenu = 'I'             -- https://docs.fivem.net/docs/game-references/input-mapper-parameter-ids/keyboard/
+Config.StressChance = 0.1         -- Default: 10% -- Percentage Stress Chance When Shooting (0-1)
+Config.UseMPH = true              -- If true speed math will be done as MPH, if false KPH will be used (YOU HAVE TO CHANGE CONTENT IN STYLES.CSS TO DISPLAY THE CORRECT TEXT)
+Config.MinimumStress = 50         -- Minimum Stress Level For Screen Shaking
 Config.MinimumSpeedUnbuckled = 50 -- Going Over This Speed Will Cause Stress
-Config.MinimumSpeed = 100 -- Going Over This Speed Will Cause Stress
-Config.DisableStress = false -- If true will disable stress completely for all players
+Config.MinimumSpeed = 100         -- Going Over This Speed Will Cause Stress
+Config.DisableStress = false      -- If true will disable stress completely for all players
 
 -- Stress:
-Config.WhitelistedVehicles = { -- Disable gaining stress from speeding in any vehicle in this table
+Config.StressDisabledVehicles = { -- Disable gaining stress from speeding in any vehicle in this table
     -- "adder",
 }
 
 
-Config.WhitelistedVehClasses = { -- Disable gaining stress from speeding in any vehicle class in this table
+Config.StressDisabledVehClasses = { -- Disable gaining stress from speeding in any vehicle class in this table
     13,
     14,
     15,
@@ -22,13 +22,13 @@ Config.WhitelistedVehClasses = { -- Disable gaining stress from speeding in any 
     21
 }
 
-Config.WhitelistedJobs = { -- Disable stress completely for players with matching job when set to true
+Config.StressDisabledJobs = { -- Disable stress completely for players with matching job when set to true
     ["police"] = true,
     ["ambulance"] = false,
     -- ["customjob"] = true
 }
 
-Config.WhitelistedWeaponArmed = { -- weapons specifically whitelisted to not show armed mode
+Config.WeaponNotArmed = { -- Weapons in this table will not show "armed" icon on hud
     -- miscellaneous
     `weapon_petrolcan`,
     `weapon_hazardcan`,
@@ -69,7 +69,7 @@ Config.WhitelistedWeaponArmed = { -- weapons specifically whitelisted to not sho
     `weapon_flare`
 }
 
-Config.WhitelistedWeaponStress = {
+Config.StressDisabledWeapon = {
     `weapon_petrolcan`,
     `weapon_hazardcan`,
     `weapon_fireextinguisher`
@@ -134,31 +134,31 @@ Config.EffectInterval = {
 }
 
 Config.Menu = {
-    isOutMapChecked = false, -- isOutMapChecked
-    isOutCompassChecked = false, -- isOutMapChecked
-    isCompassFollowChecked = true, -- isCompassFollowChecked
-    isOpenMenuSoundsChecked = true, -- isOpenMenuSoundsChecked
-    isResetSoundsChecked = true, -- isResetSoundsChecked
-    isListSoundsChecked = true, -- isListSoundsChecked
-    isMapNotifChecked = true, -- isMapNotifChecked
-    isLowFuelChecked = true, -- isLowFuelChecked
-    isCinematicNotifChecked = true, -- isCinematicNotifChecked
-    isDynamicHealthChecked = true, -- isDynamicHealthChecked
-    isDynamicArmorChecked= true, -- isDynamicArmorChecked
-    isDynamicHungerChecked = true, -- isDynamicHungerChecked
-    isDynamicThirstChecked = true, -- isDynamicThirstChecked
-    isDynamicStressChecked = true, -- isDynamicStressChecked
-    isDynamicOxygenChecked = true, -- isDynamicOxygenChecked
-    isChangeFPSChecked = true, -- isChangeFPSChecked
-    isHideMapChecked = false, -- isHideMapChecked
-    isToggleMapBordersChecked = true, -- isToggleMapBordersChecked
-    isDynamicEngineChecked = true, -- isDynamicEngineChecked
-    isDynamicNitroChecked = true, -- isDynamicNitroChecked
-    isChangeCompassFPSChecked = true, -- isChangeCompassFPSChecked
-    isCompassShowChecked = true, -- isShowCompassChecked
-    isShowStreetsChecked = true, -- isShowStreetsChecked
-    isPointerShowChecked = true, -- isPointerShowChecked
-    isDegreesShowChecked = true, -- isDegreesShowChecked
-    isCineamticModeChecked = false, -- isCineamticModeChecked
+    isOutMapChecked = false,            -- isOutMapChecked
+    isOutCompassChecked = false,        -- isOutMapChecked
+    isCompassFollowChecked = true,      -- isCompassFollowChecked
+    isOpenMenuSoundsChecked = true,     -- isOpenMenuSoundsChecked
+    isResetSoundsChecked = true,        -- isResetSoundsChecked
+    isListSoundsChecked = true,         -- isListSoundsChecked
+    isMapNotifChecked = true,           -- isMapNotifChecked
+    isLowFuelChecked = true,            -- isLowFuelChecked
+    isCinematicNotifChecked = true,     -- isCinematicNotifChecked
+    isDynamicHealthChecked = true,      -- isDynamicHealthChecked
+    isDynamicArmorChecked = true,       -- isDynamicArmorChecked
+    isDynamicHungerChecked = true,      -- isDynamicHungerChecked
+    isDynamicThirstChecked = true,      -- isDynamicThirstChecked
+    isDynamicStressChecked = true,      -- isDynamicStressChecked
+    isDynamicOxygenChecked = true,      -- isDynamicOxygenChecked
+    isChangeFPSChecked = true,          -- isChangeFPSChecked
+    isHideMapChecked = false,           -- isHideMapChecked
+    isToggleMapBordersChecked = true,   -- isToggleMapBordersChecked
+    isDynamicEngineChecked = true,      -- isDynamicEngineChecked
+    isDynamicNitroChecked = true,       -- isDynamicNitroChecked
+    isChangeCompassFPSChecked = true,   -- isChangeCompassFPSChecked
+    isCompassShowChecked = true,        -- isShowCompassChecked
+    isShowStreetsChecked = true,        -- isShowStreetsChecked
+    isPointerShowChecked = true,        -- isPointerShowChecked
+    isDegreesShowChecked = true,        -- isDegreesShowChecked
+    isCineamticModeChecked = false,     -- isCineamticModeChecked
     isToggleMapShapeChecked = 'square', -- isToggleMapShapeChecked
 }

--- a/config.lua
+++ b/config.lua
@@ -6,9 +6,28 @@ Config.UseMPH = true -- If true speed math will be done as MPH, if false KPH wil
 Config.MinimumStress = 50 -- Minimum Stress Level For Screen Shaking
 Config.MinimumSpeedUnbuckled = 50 -- Going Over This Speed Will Cause Stress
 Config.MinimumSpeed = 100 -- Going Over This Speed Will Cause Stress
-Config.DisablePoliceStress = true -- If true will disable stress for people with the police job
+Config.DisableStress = false -- If true will disable stress completely for all players
 
--- Stress
+-- Stress:
+Config.WhitelistedVehicles = { -- Disable gaining stress from speeding in any vehicle in this table
+    -- "adder",
+}
+
+
+Config.WhitelistedVehClasses = { -- Disable gaining stress from speeding in any vehicle class in this table
+    13,
+    14,
+    15,
+    16,
+    21
+}
+
+Config.WhitelistedJobs = { -- Disable stress completely for players with matching job when set to true
+    ["police"] = true,
+    ["ambulance"] = false,
+    -- ["customjob"] = true
+}
+
 Config.WhitelistedWeaponArmed = { -- weapons specifically whitelisted to not show armed mode
     -- miscellaneous
     `weapon_petrolcan`,

--- a/server.lua
+++ b/server.lua
@@ -20,8 +20,10 @@ end, 'admin')
 RegisterNetEvent('hud:server:GainStress', function(amount)
     local src = source
     local Player = QBCore.Functions.GetPlayer(src)
+    local playerJob = Player.PlayerData.job.name
     local newStress
-    if not Player or (Config.DisablePoliceStress and Player.PlayerData.job.name == 'police') then return end
+
+    if not Player or Config.DisableStress or Config.WhitelistedJobs[playerJob] then return end
     if not ResetStress then
         if not Player.PlayerData.metadata['stress'] then
             Player.PlayerData.metadata['stress'] = 0


### PR DESCRIPTION
Adds configuration options to disable stress for jobs, vehicles, vehicle classes, or disable completely.

Suggested in issue #151


## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
