### PR TITLE
Fix mic icon color for radio

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -26,6 +26,7 @@ local showSquareB = false
 local Menu = config.Menu
 local CinematicHeight = 0.2
 local w = 0
+local radioActive = false
 
 DisplayRadar(false)
 
@@ -109,6 +110,10 @@ AddEventHandler('onResourceStart', function(resourceName)
     Wait(2000)
     local hudSettings = GetResourceKvpString('hudSettings')
     if hudSettings then loadSettings(json.decode(hudSettings)) end
+end)
+
+AddEventHandler("pma-voice:radioActive", function(data)
+    radioActive = data
 end)
 
 -- Callbacks & Events
@@ -635,6 +640,7 @@ local function updatePlayerHud(data)
             engine = data[28],
             cinematic = data[29],
             dev = data[30],
+            radioActive = data[31],
         })
     end
 end
@@ -751,6 +757,7 @@ CreateThread(function()
                 -1,
                 Menu.isCineamticModeChecked,
                 dev,
+                radioActive,
             })
             end
             -- Vehicle hud
@@ -794,6 +801,7 @@ CreateThread(function()
                     (GetVehicleEngineHealth(vehicle) / 10),
                     Menu.isCineamticModeChecked,
                     dev,
+                    radioActive,
                 })
                 updateVehicleHud({
                     show,

--- a/html/app.js
+++ b/html/app.js
@@ -776,6 +776,7 @@ const playerHud = {
       hungerColor: "",
       healthColor: "",
       thirstColor: "",
+      radioActive: false,
     };
   },
   
@@ -804,6 +805,7 @@ const playerHud = {
       this.voice = data.voice;
       this.talking = data.talking;
       this.radio = data.radio;
+      this.radioActive = data.radioActive;
       this.nos = data.nos;
       this.oxygen = data.oxygen;
       this.cruise = data.cruise;
@@ -945,7 +947,7 @@ const playerHud = {
         this.nosColor = "#FFFFFF";
       }
 
-      if (data.talking && data.radio) {
+      if (data.talking && data.radioActive) {
         this.talkingColor = "#D64763";
       } else if (data.talking) {
         this.talkingColor = '#FFFF3E';

--- a/html/app.js
+++ b/html/app.js
@@ -947,7 +947,7 @@ const playerHud = {
         this.nosColor = "#FFFFFF";
       }
 
-      if (data.talking && data.radioActive) {
+      if (data.radioActive) {
         this.talkingColor = "#D64763";
       } else if (data.talking) {
         this.talkingColor = '#FFFF3E';


### PR DESCRIPTION
Previously:
The mic icon would be white when not speaking, yellow when speaking in proximity, and red when speaking in prox or over radio when radio is on.

Now:
White when not speaking, yellow when speaking in prox, and red when speaking over the radio.

Small change, but this has bugged me for months lmao
Seems to be the intended behavior anyway


## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
