### PR TITLE
Utilise (type) check for police jobs, add 'ambulance' job to stress whitelist. Typo fix.

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -52,8 +52,8 @@ local function loadSettings(settings)
         if k == 'isToggleMapShapeChecked' then
             Menu.isToggleMapShapeChecked = v
             SendNUIMessage({ test = true, event = k, toggle = v})
-        elseif k == 'isCineamticModeChecked' then
-            Menu.isCineamticModeChecked = v
+        elseif k == 'isCinematicModeChecked' then
+            Menu.isCinematicModeChecked = v
             CinematicShow(v)
             SendNUIMessage({ test = true, event = k, toggle = v})
         elseif k == 'isChangeFPSChecked' then
@@ -528,16 +528,16 @@ end)
 
 RegisterNUICallback('cinematicMode', function(_, cb)
     Wait(50)
-    if Menu.isCineamticModeChecked then
+    if Menu.isCinematicModeChecked then
         CinematicShow(false)
-        Menu.isCineamticModeChecked = false
+        Menu.isCinematicModeChecked = false
         if Menu.isCinematicNotifChecked then
             QBCore.Functions.Notify(Lang:t("notify.cinematic_off"), 'error')
         end
         DisplayRadar(1)
     else
         CinematicShow(true)
-        Menu.isCineamticModeChecked = true
+        Menu.isCinematicModeChecked = true
         if Menu.isCinematicNotifChecked then
             QBCore.Functions.Notify(Lang:t("notify.cinematic_on"))
         end
@@ -755,7 +755,7 @@ CreateThread(function()
                 hp,
                 math.ceil(GetEntitySpeed(vehicle) * speedMultiplier),
                 -1,
-                Menu.isCineamticModeChecked,
+                Menu.isCinematicModeChecked,
                 dev,
                 radioActive,
             })
@@ -799,7 +799,7 @@ CreateThread(function()
                     hp,
                     math.ceil(GetEntitySpeed(vehicle) * speedMultiplier),
                     (GetVehicleEngineHealth(vehicle) / 10),
-                    Menu.isCineamticModeChecked,
+                    Menu.isCinematicModeChecked,
                     dev,
                     radioActive,
                 })

--- a/config.lua
+++ b/config.lua
@@ -6,7 +6,7 @@ Config.UseMPH = true -- If true speed math will be done as MPH, if false KPH wil
 Config.MinimumStress = 50 -- Minimum Stress Level For Screen Shaking
 Config.MinimumSpeedUnbuckled = 50 -- Going Over This Speed Will Cause Stress
 Config.MinimumSpeed = 100 -- Going Over This Speed Will Cause Stress
-Config.DisablePoliceStress = true -- If true will disable stress for people with the police job
+Config.DisableEmsStress = true -- If true will disable stress for people with police or ambulance job(s)
 
 -- Stress
 Config.WhitelistedWeaponArmed = { -- weapons specifically whitelisted to not show armed mode

--- a/config.lua
+++ b/config.lua
@@ -140,6 +140,6 @@ Config.Menu = {
     isShowStreetsChecked = true, -- isShowStreetsChecked
     isPointerShowChecked = true, -- isPointerShowChecked
     isDegreesShowChecked = true, -- isDegreesShowChecked
-    isCineamticModeChecked = false, -- isCineamticModeChecked
+    isCinematicModeChecked = false, -- isCinematicModeChecked
     isToggleMapShapeChecked = 'square', -- isToggleMapShapeChecked
 }

--- a/html/app.js
+++ b/html/app.js
@@ -29,7 +29,7 @@ const app = Vue.createApp({
       isShowStreetsChecked: this.initIsShowStreetsChecked(),
       isPointerShowChecked: this.initIsPointerShowChecked(),
       isDegreesShowChecked: this.initIsDegreesShowChecked(),
-      isCineamticModeChecked: this.initIsCineamticModeChecked(),
+      isCinematicModeChecked: this.initisCinematicModeChecked(),
 		};
 	},
   setup () {
@@ -152,8 +152,8 @@ const app = Vue.createApp({
     isDegreesShowChecked: function() {
 			localStorage.setItem("isDegreesShowChecked", this.isDegreesShowChecked);
 		},
-    isCineamticModeChecked: function() {
-			localStorage.setItem("isCineamticModeChecked", this.isCineamticModeChecked);
+    isCinematicModeChecked: function() {
+			localStorage.setItem("isCinematicModeChecked", this.isCinematicModeChecked);
 		},
 	},
   methods: {
@@ -365,8 +365,8 @@ const app = Vue.createApp({
 				return stored == 'true';
 			}
 		},
-    initIsCineamticModeChecked: function() {
-			const stored = localStorage.getItem("isCineamticModeChecked");
+    initisCinematicModeChecked: function() {
+			const stored = localStorage.getItem("isCinematicModeChecked");
 			if (stored === null) {
 				return false;
 			} else {

--- a/html/index.html
+++ b/html/index.html
@@ -181,7 +181,7 @@
                                 <hr>
                                 <div class="text-h6 q-mb-md">Cinematic Mode</div>
                                 <div class="text-h7">
-                                    <q-checkbox v-on:click="cinematicMode($event)" label='Enabled' v-model="isCineamticModeChecked" color="checkbox" val="23" style="display: flex;"></q-checkbox>
+                                    <q-checkbox v-on:click="cinematicMode($event)" label='Enabled' v-model="isCinematicModeChecked" color="checkbox" val="23" style="display: flex;"></q-checkbox>
                                 </div>
                                 <br>
                             </q-tab-panel>

--- a/server.lua
+++ b/server.lua
@@ -21,7 +21,7 @@ RegisterNetEvent('hud:server:GainStress', function(amount)
     local src = source
     local Player = QBCore.Functions.GetPlayer(src)
     local newStress
-    if not Player or (Config.DisablePoliceStress and Player.PlayerData.job.name == 'police') then return end
+    if not Player or (Config.DisableEmsStress and Player.PlayerData.job.type == 'leo' or Player.PlayerData.job.name == 'ambulance') then return end
     if not ResetStress then
         if not Player.PlayerData.metadata['stress'] then
             Player.PlayerData.metadata['stress'] = 0


### PR DESCRIPTION
## Description

Utilises the '.type' check for police job, for those servers who have multiple departments rather then having multiple 'job.name' checks. I've also added 'ambulance' job and reflected the change by renaming 'Config.DisablePoliceStress' to 'Config.DisableEmsStress'.

## Checklist

- [X] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [X] My code fits the style guidelines.
- [X] My PR fits the contribution guidelines.
