### PR TITLE
Added Disable Job Stress

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
     "Lua.runtime.nonstandardSymbol": ["/**/", "`", "+=", "-=", "*=", "/="],
-    "Lua.runtime.version": "Lua 5.4"
+    "Lua.runtime.version": "Lua 5.4",
+    "githubPullRequests.ignoredPullRequestBranches": [
+        "main"
+    ]
 }

--- a/config.lua
+++ b/config.lua
@@ -7,6 +7,7 @@ Config.MinimumStress = 50 -- Minimum Stress Level For Screen Shaking
 Config.MinimumSpeedUnbuckled = 50 -- Going Over This Speed Will Cause Stress
 Config.MinimumSpeed = 100 -- Going Over This Speed Will Cause Stress
 Config.DisablePoliceStress = true -- If true will disable stress for people with the police job
+Config.DisableAmbulanceStress = true -- if true will disable stress for people with ambulance job
 
 -- Stress
 Config.WhitelistedWeaponArmed = { -- weapons specifically whitelisted to not show armed mode

--- a/config.lua
+++ b/config.lua
@@ -6,13 +6,12 @@ Config.UseMPH = true -- If true speed math will be done as MPH, if false KPH wil
 Config.MinimumStress = 50 -- Minimum Stress Level For Screen Shaking
 Config.MinimumSpeedUnbuckled = 50 -- Going Over This Speed Will Cause Stress
 Config.MinimumSpeed = 100 -- Going Over This Speed Will Cause Stress
-
--- List of Jobs to disable stress for
-Config.DisableJobStress = {
-    'police',
-    'ambulance',
-    'tow'
-}
+Config.DisableStress = false -- Disable Stress for everyone
+Config.DisableJobStress = { -- Disable job for specific jobs
+    ["police"] = true,
+    ["ambulance"] = true,
+    ["taxi"] = false
+  }
 
 -- Stress
 Config.WhitelistedWeaponArmed = { -- weapons specifically whitelisted to not show armed mode

--- a/config.lua
+++ b/config.lua
@@ -6,8 +6,13 @@ Config.UseMPH = true -- If true speed math will be done as MPH, if false KPH wil
 Config.MinimumStress = 50 -- Minimum Stress Level For Screen Shaking
 Config.MinimumSpeedUnbuckled = 50 -- Going Over This Speed Will Cause Stress
 Config.MinimumSpeed = 100 -- Going Over This Speed Will Cause Stress
-Config.DisablePoliceStress = true -- If true will disable stress for people with the police job
-Config.DisableAmbulanceStress = true -- if true will disable stress for people with ambulance job
+
+-- List of Jobs to disable stress for
+Config.DisableJobStress = {
+    'police',
+    'ambulance',
+    'tow'
+}
 
 -- Stress
 Config.WhitelistedWeaponArmed = { -- weapons specifically whitelisted to not show armed mode

--- a/server.lua
+++ b/server.lua
@@ -22,6 +22,7 @@ RegisterNetEvent('hud:server:GainStress', function(amount)
     local Player = QBCore.Functions.GetPlayer(src)
     local newStress
     if not Player or (Config.DisablePoliceStress and Player.PlayerData.job.name == 'police') then return end
+    if not Player or (Config.DisableAmbulanceStress and Player.PlayerData.job.name == 'ambulance') then return end
     if not ResetStress then
         if not Player.PlayerData.metadata['stress'] then
             Player.PlayerData.metadata['stress'] = 0

--- a/server.lua
+++ b/server.lua
@@ -20,12 +20,11 @@ end, 'admin')
 RegisterNetEvent('hud:server:GainStress', function(amount)
     local src = source
     local Player = QBCore.Functions.GetPlayer(src)
+    local playerJob = Player.PlayerData.job.name
     local newStress
-    for _,i in ipairs(Config.DisableJobStress) do
-        if Player.PlayerData.job.name == i then
-            return
-        end
-    end
+    -- if not Player or (Config.DisablePoliceStress and Player.PlayerData.job.name == 'police') then return end
+    -- if not Player or (Config.DisableAmbulanceStress and Player.PlayerData.job.name == 'ambulance') then return end
+    if not Player or Config.DisableStress or Config.DisableJobStress[playerJob] then return end
     if not ResetStress then
         if not Player.PlayerData.metadata['stress'] then
             Player.PlayerData.metadata['stress'] = 0

--- a/server.lua
+++ b/server.lua
@@ -22,8 +22,7 @@ RegisterNetEvent('hud:server:GainStress', function(amount)
     local Player = QBCore.Functions.GetPlayer(src)
     local playerJob = Player.PlayerData.job.name
     local newStress
-    -- if not Player or (Config.DisablePoliceStress and Player.PlayerData.job.name == 'police') then return end
-    -- if not Player or (Config.DisableAmbulanceStress and Player.PlayerData.job.name == 'ambulance') then return end
+    
     if not Player or Config.DisableStress or Config.DisableJobStress[playerJob] then return end
     if not ResetStress then
         if not Player.PlayerData.metadata['stress'] then

--- a/server.lua
+++ b/server.lua
@@ -21,8 +21,11 @@ RegisterNetEvent('hud:server:GainStress', function(amount)
     local src = source
     local Player = QBCore.Functions.GetPlayer(src)
     local newStress
-    if not Player or (Config.DisablePoliceStress and Player.PlayerData.job.name == 'police') then return end
-    if not Player or (Config.DisableAmbulanceStress and Player.PlayerData.job.name == 'ambulance') then return end
+    for _,i in ipairs(Config.DisableJobStress) do
+        if Player.PlayerData.job.name == i then
+            return
+        end
+    end
     if not ResetStress then
         if not Player.PlayerData.metadata['stress'] then
             Player.PlayerData.metadata['stress'] = 0


### PR DESCRIPTION
## Description

Updated this from my previous pull request to use a list of jobs to disable stress for.
config.lua::Config.DisableJobStress{} -- will be the list for jobs to disable stress for.

I have tested this on the latest qbcore-framework/qb-hub with an up to date FiveM server

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
