### PR TITLE
Fix issue when vehicle health returns NaN

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -765,6 +765,10 @@ CreateThread(function()
                     DisplayRadar(true)
                 end
                 wasInVehicle = true
+                local engineHealth = GetVehicleEngineHealth(vehicle)
+                if engineHealth ~= engineHealth then -- This checks for NaN, as any NaN value is not equal to itself
+                    engineHealth = 0
+                end
                 updatePlayerHud({
                     show,
                     Menu.isDynamicHealthChecked,
@@ -793,7 +797,7 @@ CreateThread(function()
                     harness,
                     hp,
                     math.ceil(GetEntitySpeed(vehicle) * speedMultiplier),
-                    (GetVehicleEngineHealth(vehicle) / 10),
+                    (engineHealth / 10),
                     Menu.isCinematicModeChecked,
                     dev,
                     radioActive,


### PR DESCRIPTION
## Description

Fix the following error when vehicle health returns NaN:
![image](https://github.com/user-attachments/assets/c30003e0-26ff-42c0-a32a-cc635f0ce9d2)

## Checklist

- [ x ] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [ x ] My code fits the style guidelines.
- [ x ] My PR fits the contribution guidelines.
