### PR TITLE
Fix: Hide the default health and armour displays when the minimap is visible

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -1034,7 +1034,12 @@ CreateThread(function()
             Wait(1)
         end
     end
+
     while true do
+        BeginScaleformMovieMethod(minimap, 'SETUP_HEALTH_ARMOUR')
+        ScaleformMovieMethodAddParamInt(3)
+        EndScaleformMovieMethod()
+
         if w > 0 then
             BlackBars()
             DisplayRadar(0)


### PR DESCRIPTION
## Description

This PR fixes an issue with the enhanced version of qb-hud, the vanilla health and armour arcs render around the minimap because Enhanced ignores stream/ overrides of base game assets, so the `minimap.gfx` that strips them on legacy never loads. This was fixed by calling the minimap scaleform's `SETUP_HEALTH_ARMOUR` with mode 3 each frame to hide both arcs at runtime, which works regardless of whether the asset override took effect.

### Before Changes
<img width="520" height="346" alt="Screenshot 2026-07-27 144955" src="https://github.com/user-attachments/assets/d8093fd4-ba0e-49ea-850d-9e5b1062f867" />

### After Changes
<img width="520" height="346" alt="image" src="https://github.com/user-attachments/assets/2e3c9f42-0712-4e83-a976-0572532b9a64" />

## Checklist
- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.