### PR TITLE
Fix insecure hud:server:RelieveStress input handling

### DIFF
--- a/server.lua
+++ b/server.lua
@@ -45,6 +45,9 @@ end)
 RegisterNetEvent('hud:server:RelieveStress', function(amount)
     if Config.DisableStress then return end
     local src = source
+    if type(amount) ~= 'number' then return end
+    amount = math.floor(amount)
+    if amount <= 0 or amount > 100 then return end
     local Player = exports['qb-core']:GetPlayer(src)
     local newStress
     if not Player then return end


### PR DESCRIPTION
## Summary\n- add strict server-side validation for mount in hud:server:RelieveStress\n- reject non-numeric, non-positive, and out-of-range values before metadata updates\n- normalize accepted input to integers\n\n## Why\nThis prevents malformed or abusive event payloads from forcing invalid stress mutations through the public net event path.\n\nCloses #203